### PR TITLE
Pass string to class_name has_many option

### DIFF
--- a/lib/inviter/acts_as_inviter.rb
+++ b/lib/inviter/acts_as_inviter.rb
@@ -6,7 +6,7 @@ module Inviter
     end
 
     included do
-      has_many :sent_invitations, as: :inviter, class_name: Invitation
+      has_many :sent_invitations, as: :inviter, class_name: "Invitation"
     end
 
     def send_invitation(invitee, invited_to)


### PR DESCRIPTION
Rails console was failing with error `A class was passed to `:class_name` but we are expecting a string.`